### PR TITLE
Integrate consul demo from SE hack day

### DIFF
--- a/application/Dockerfile
+++ b/application/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3
 
-RUN pip3 install Flask mysql-connector-python hvac
+RUN pip3 install Flask mysql-connector-python hvac requests
 
 WORKDIR /usr/src/app
 ADD templates ./templates/

--- a/application/config.ini.ctmpl
+++ b/application/config.ini.ctmpl
@@ -19,4 +19,4 @@ KeyPath=lob_a/workshop/transit
 KeyName=customer-key
 
 [CONSUL]
-DEBUG=False
+DEBUG = {{ key "service/profitapp/debug" }}

--- a/application/templates/base.html
+++ b/application/templates/base.html
@@ -21,7 +21,11 @@
               <a class="navbar-item is-selected" href="/">
                 Home
               </a>
-
+	      {% if conf['CONSUL']['DEBUG'] == 'True'  %}
+              <a class="navbar-item is-selected" href="serviced">
+                Service Discovery
+              </a>
+	      {% endif %}
               <a class="navbar-item" href="records">
                 Records
               </a>
@@ -58,7 +62,7 @@
   <footer class="footer">
     <div class="content has-text-centered">
       <p>
-        <strong>Vault by Hashicorp</strong>. <br> <a href="https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit"> Encryption as a Service</a> using <br> the <a href="https://www.vaultproject.io/docs/secrets/transit/index.html">transit secret engine.</a> 
+        <strong>Vault by Hashicorp</strong>. <br> <a href="https://learn.hashicorp.com/vault/encryption-as-a-service/eaas-transit"> Encryption as a Service</a> using <br> the <a href="https://www.vaultproject.io/docs/secrets/transit/index.html">transit secret engine.</a> <br> Processed by {{hostname}}
       </p>
     </div>
   </footer>

--- a/application/templates/serviced.html
+++ b/application/templates/serviced.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+
+{% block content %}
+  
+<div class="tile is-ancestor">
+  <div class="tile is-vertical is-parent">
+      <p class="title">Service Discovery</p>
+      <div class="columns">
+      {% for dc in datacenters %}
+          <div class="column" style='background-color:{{ dc.color }}'>
+             <p class="title">{{ dc.location }}</p>
+             <p class="appurl">{{ dc.url}}</p>
+	     <p class="numofinstances">Number of Instances: 3</p>
+             <p class="attribute">Allocation ID: {{ dc.jsonResult['NOMAD_ALLOC_ID'] }}</p>
+             <p class="attribute">Availability Zone: {{ dc.jsonResult['NOMAD_DC'] }}</p>
+             <p class="attribute">Endpoint: {{ dc.jsonResult['NOMAD_ADDR_http'] }}</p>
+             <p class="attribute">Key Value of Fruit: {{ dc.jsonResult['KV_FRUIT'] }}</p>
+          </div>
+      {% endfor %}
+      </div>
+  
+  </div>
+</div>
+
+{% endblock %}

--- a/terraform/admin/nomad/application-deployment/spork-backendsvc/profit-us-east-1.hcl
+++ b/terraform/admin/nomad/application-deployment/spork-backendsvc/profit-us-east-1.hcl
@@ -1,0 +1,133 @@
+job "profit" {
+  region = "us-east-1"
+  datacenters = ["us-east-1a", "us-east-1b", "us-east-1c"]
+  type = "service"
+  priority = 50
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+  update {
+    # Stagger updates every 10 seconds
+    stagger = "10s"
+
+    # Update a single task at a time
+    max_parallel = 1
+  }
+  group "magenta" {
+    count = 2
+    restart {
+      attempts = 2
+      interval = "1m"
+      delay    = "10s"
+      mode     = "fail"
+    }
+
+    task "profitapp" {
+      driver = "docker"
+      config {
+        image      = "arodd/spork-backendsvc:latest"
+        force_pull = true
+        port_map {
+          http = 8080
+        }
+      }
+      service {
+        name = "profitapp"
+        tags = ["profit", "${attr.consul.datacenter}", "${NOMAD_GROUP_NAME}", "${node.datacenter}"]
+        port = "http"
+        check {
+          name     = "alive"
+          type     = "http"
+          interval = "10s"
+          timeout  = "3s"
+          path     = "/"
+        }
+      }
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 128 # 128MB
+        network {
+          mbits = 1 
+          port "http" {
+            static = 8080
+          }
+        }
+      }
+      logs {
+        max_files     = 10
+        max_file_size = 15
+      }
+      template {
+        data = <<EOH
+KV_FRUIT="{{key "service/profitapp/magenta/fruit"}}"
+EOH
+        destination = "secrets/file.env"
+        env         = true
+      }
+      vault {
+        policies = ["vault-admin"]
+      }
+      kill_timeout = "30s"
+    }
+  }
+  group "yellow" {
+    count = 1
+    restart {
+      attempts = 2
+      interval = "1m"
+      delay    = "10s"
+      mode     = "fail"
+    }
+
+    task "profitapp" {
+      driver = "docker"
+      config {
+        image      = "arodd/spork-backendsvc:latest"
+        force_pull = true
+        port_map {
+          http = 8080
+        }
+      }
+      service {
+        name = "profitapp"
+        tags = ["profit", "${attr.consul.datacenter}", "${NOMAD_GROUP_NAME}", "${node.datacenter}"]
+        port = "http"
+        check {
+          name     = "alive"
+          type     = "http"
+          interval = "10s"
+          timeout  = "3s"
+          path     = "/"
+        }
+      }
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 128 # 128MB
+        network {
+          mbits = 1
+          port "http" {
+            static = 8080
+          }
+        }
+      }
+      logs {
+        max_files     = 10
+        max_file_size = 15
+      }
+
+      template {
+        data = <<EOH
+KV_FRUIT="{{key "service/profitapp/yellow/fruit"}}"
+EOH
+        destination = "secrets/file.env"
+        env         = true
+      }
+      vault {
+        policies = ["vault-admin"]
+      }
+      kill_timeout = "30s"
+    }
+  }
+}

--- a/terraform/admin/nomad/application-deployment/spork-backendsvc/profit-us-west-2.hcl
+++ b/terraform/admin/nomad/application-deployment/spork-backendsvc/profit-us-west-2.hcl
@@ -1,0 +1,131 @@
+job "profit" {
+  region = "us-west-2"
+  datacenters = ["us-west-2a", "us-west-2b", "us-west-2c"]
+  type = "service"
+  priority = 50
+
+  constraint {
+    attribute = "${attr.kernel.name}"
+    value     = "linux"
+  }
+  update {
+    # Stagger updates every 10 seconds
+    stagger = "10s"
+    # Update a single task at a time
+    max_parallel = 1
+  }
+  group "magenta" {
+    count = 1
+    restart {
+      attempts = 2
+      interval = "1m"
+      delay    = "10s"
+      mode     = "fail"
+    }
+
+    task "profitapp" {
+      driver = "docker"
+      config {
+        image      = "arodd/spork-backendsvc:latest"
+        force_pull = true
+        port_map {
+          http = 8080
+        }
+      }
+      service {
+        name = "profitapp"
+        tags = ["profit", "${attr.consul.datacenter}", "${NOMAD_GROUP_NAME}", "${node.datacenter}"]
+        port = "http"
+        check {
+          name     = "alive"
+          type     = "http"
+          interval = "10s"
+          timeout  = "3s"
+          path     = "/"
+        }
+      }
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 128 # 128MB
+        network {
+          mbits = 1
+          port "http" {
+            static = 8080
+          }
+        }
+      }
+      logs {
+        max_files     = 10
+        max_file_size = 15
+      }
+      template {
+        data = <<EOH
+KV_FRUIT="{{key "service/profitapp/magenta/fruit"}}"
+EOH
+        destination = "secrets/file.env"
+        env         = true
+      }
+      vault {
+        policies = ["vault-admin"]
+      }
+      kill_timeout = "30s"
+    }
+  }
+  group "yellow" {
+    count = 2
+    restart {
+      attempts = 2
+      interval = "1m"
+      delay    = "10s"
+      mode     = "fail"
+    }
+
+    task "profitapp" {
+      driver = "docker"
+      config {
+        image      = "arodd/spork-backendsvc:latest"
+        force_pull = true
+        port_map {
+          http = 8080
+        }
+      }
+      service {
+        name = "profitapp"
+        tags = ["profit", "${attr.consul.datacenter}", "${NOMAD_GROUP_NAME}", "${node.datacenter}"]
+        port = "http"
+        check {
+          name     = "alive"
+          type     = "http"
+          interval = "10s"
+          timeout  = "3s"
+          path     = "/"
+        }
+      }
+      resources {
+        cpu    = 500 # 500 MHz
+        memory = 128 # 128MB
+        network {
+          mbits = 1
+          port "http" {
+            static = 8080
+          }
+        }
+      }
+      logs {
+        max_files     = 10
+        max_file_size = 15
+      }
+      template {
+        data = <<EOH
+KV_FRUIT="{{key "service/profitapp/yellow/fruit"}}"
+EOH
+        destination = "secrets/file.env"
+        env         = true
+      }
+      vault {
+        policies = ["vault-admin"]
+      }
+      kill_timeout = "30s"
+    }
+  }
+}


### PR DESCRIPTION
The consul team created the following:

- A new service discovery page
- A new CONSUL section in the config.ini with a debug variable
- Debug = false disables the service discovery section
- Service discovery shows information from the backend profitapp
- Profitapp is a nomad job running in us-east and us-west and we can stop a region to show failover
- We can leverage consul-template to update the config.ini in real-time to show the service discovery page or not