### PR TITLE
Fixing CentOS 7 cloud-init-output.log

### DIFF
--- a/packer/scripts/centos-7.sh
+++ b/packer/scripts/centos-7.sh
@@ -2,3 +2,4 @@
 set -x
 
 # Centos7 Specific Setup Here
+echo 'output: { all: "| tee -a /var/log/cloud-init-output.log" }' | sudo tee -a /etc/cloud/cloud.cfg.d/05_logging.cfg


### PR DESCRIPTION
Adding cloud-init log configuration for centos to output to /var/log/cloud-init-output.log to assist with debugging periodic hashistack issues.